### PR TITLE
feat: make it possible to choose image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Once you have Rust setup, a simple `cargo build --release` should produce your v
 ## Use with Github Actions
 
 We created a Github Action to make it easy to use molnctl in your builds, see [setup-molnctl-action](https://github.com/molnett/setup-molnctl-action).
+There is also a Github Action for working with ephemeral environments, see [ephemeral-environment-action](https://github.com/molnett/ephemeral-environment-action)
 
 ## Usage
 

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -43,7 +43,6 @@ impl Token {
 }
 
 pub struct UserConfigLoader {
-    pub path: Utf8PathBuf,
 }
 
 impl UserConfig {


### PR DESCRIPTION
Extends the `svcs image-name` command to be able to specify a custom image name instead of using the folder name