### PR TITLE
refactor userconfig into singleton, hide commands based on permissions

### DIFF
--- a/src/commands/environments.rs
+++ b/src/commands/environments.rs
@@ -1,5 +1,5 @@
 use super::CommandBase;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use dialoguer::FuzzySelect;
 use tabled::Table;
@@ -54,13 +54,10 @@ pub struct Create {
 impl Create {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
         let response = base.api_client().create_environment(
-            token,
+            &token,
             &self.name,
             &org_name,
             self.copy_from.as_deref(),
@@ -79,12 +76,9 @@ pub struct List {}
 impl List {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
-        let response = base.api_client().get_environments(token, &org_name)?;
+        let response = base.api_client().get_environments(&token, &org_name)?;
 
         let table = Table::new(response.environments).to_string();
         println!("{}", table);
@@ -104,10 +98,7 @@ pub struct Delete {
 impl Delete {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
         if !self.confirm_deletion(&org_name)? {
             println!("Delete cancelled");
@@ -115,7 +106,7 @@ impl Delete {
         }
 
         base.api_client()
-            .delete_environment(token, &org_name, &self.name)?;
+            .delete_environment(&token, &org_name, &self.name)?;
 
         println!("Environment {} deleted", self.name);
         Ok(())

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use crate::config::user::UserConfig;
+
+// This just serves as an example for now
+// of how to create a command that is hidden from the help menu
+// based on the user's permissions.
+
+pub fn is_hidden() -> bool {
+    !UserConfig::get_permissions().contains(&"tenant:manage".to_string())
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    author,
+    version,
+    about,
+    long_about,
+    subcommand_required = true,
+    arg_required_else_help = true,
+    hide = is_hidden(),
+)]
+pub struct Projects {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+impl Projects {
+    pub fn execute(self) -> Result<()> {
+        match self.command {
+            None => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+}

--- a/src/commands/secrets.rs
+++ b/src/commands/secrets.rs
@@ -1,5 +1,5 @@
 use super::CommandBase;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use dialoguer::{FuzzySelect, Input};
 use std::io::{self, BufRead};
@@ -54,10 +54,7 @@ pub struct Create {
 impl Create {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
         let value: String = if let Some(true) = self.stdin {
             self.read_stdin()?
@@ -69,7 +66,7 @@ impl Create {
         };
 
         base.api_client()
-            .create_secret(token, &org_name, &self.env, &self.name, &value)?;
+            .create_secret(&token, &org_name, &self.env, &self.name, &value)?;
 
         println!("Secret {} created", &self.name);
         Ok(())
@@ -106,12 +103,9 @@ pub struct List {
 impl List {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
-        let response = base.api_client().get_secrets(token, &org_name, &self.env)?;
+        let response = base.api_client().get_secrets(&token, &org_name, &self.env)?;
 
         let table = Table::new(response.secrets).to_string();
         println!("{}", table);
@@ -133,10 +127,7 @@ pub struct Delete {
 impl Delete {
     pub fn execute(self, base: CommandBase) -> Result<()> {
         let org_name = base.get_org()?;
-        let token = base
-            .user_config()
-            .get_token()
-            .ok_or_else(|| anyhow!("No token found. Please login first."))?;
+        let token = base.get_token()?;
 
         if let Some(false) = self.no_confirm {
             let prompt = format!("Org: {}, Environment: {}, Secret: {}. Are you sure you want to delete this secret?", org_name, self.env, self.name);
@@ -149,7 +140,7 @@ impl Delete {
         }
 
         base.api_client()
-            .delete_secret(token, &org_name, &self.env, &self.name)?;
+            .delete_secret(&token, &org_name, &self.env, &self.name)?;
 
         println!("Secret {} deleted", self.name);
         Ok(())

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -1,14 +1,19 @@
 use camino::Utf8PathBuf;
 use config::Config;
-
+use once_cell::unsync::OnceCell;
+use anyhow::{Result, anyhow};
+use std::cell::RefCell;
 
 use crate::Cli;
-
 use super::{default_user_config_path, write_to_disk_json, Error};
+
+thread_local! {
+    static CONFIG: OnceCell<RefCell<UserConfig>> = OnceCell::new();
+}
 
 #[derive(Debug, Clone)]
 pub struct UserConfig {
-    config: UserConfigInner,
+    inner: UserConfigInner,
     disk_config: UserConfigInner,
     path: Utf8PathBuf,
 }
@@ -19,10 +24,16 @@ pub struct UserConfigInner {
     default_org: Option<String>,
     #[serde(default = "default_url")]
     url: String,
+    #[serde(default = "default_permissions")]
+    permissions: Vec<String>,
 }
 
 fn default_url() -> String {
     "https://api.molnett.org".to_string()
+}
+
+fn default_permissions() -> Vec<String> {
+    vec!["superadmin".to_string()]
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -46,53 +57,79 @@ pub struct UserConfigLoader {
 }
 
 impl UserConfig {
-    pub fn new(cli: &Cli) -> Self {
-        let config_path = match &cli.config {
-            Some(path) => path.clone(),
-            None => default_user_config_path()
-                .expect("No config path provided and default path not found"),
-        };
-        let mut config =
-            UserConfigLoader::load(&config_path).expect("Loading config from disk failed");
-
-        // TODO: write config to disk after reading so it gets written if it doesn't exist
-
-        if let Some(h) = &cli.url {
-            config.set_url(h.to_string());
-        }
-
-        config
+    pub fn load_from_disk() -> Result<()> {
+        let config_path = default_user_config_path()?;
+        let config = UserConfigLoader::load(&config_path)?;
+        CONFIG.with(|cell| cell.set(RefCell::new(config)))
+            .map_err(|_| anyhow!("UserConfig has already been initialized"))
     }
-    pub fn get_token(&self) -> Option<&str> {
-        self.config.token.as_ref().map(|u| u.access_token.as_str())
-    }
-    pub fn is_token_expired(&self) -> bool {
-        if let Some(token) = &self.config.token {
-            if let Some(expiry) = token.expiry {
-                return expiry < chrono::Utc::now();
+
+    pub fn apply_cli_options(cli: &Cli) {
+        CONFIG.with(|cell| {
+            let mut config = cell.get().expect("UserConfig has not been initialized").borrow_mut();
+
+            if let Some(url) = &cli.url {
+                config.inner.url = url.to_string();
             }
-        }
-        true
-    }
-    pub fn write_token(&mut self, token: Token) -> Result<(), super::Error> {
-        self.disk_config.token = Some(token.clone());
-        self.config.token = Some(token);
 
-        write_to_disk_json(&self.path, &self.disk_config)
+            config.inner.permissions = vec!["superadmin".to_string()];
+        });
     }
-    pub fn write_default_org(&mut self, org_name: String) -> Result<(), super::Error> {
-        self.disk_config.default_org = Some(org_name.clone());
-        self.config.default_org = Some(org_name);
-        write_to_disk_json(&self.path, &self.disk_config)
+
+    pub fn get_token() -> Option<String> {
+        CONFIG.with(|cell| {
+            let config = cell.get().expect("UserConfig has not been initialized").borrow();
+            config.inner.token.as_ref().map(|u| u.access_token.as_str()).map(|t| t.to_string())
+        })
     }
-    pub fn get_default_org(&self) -> Option<&str> {
-        self.config.default_org.as_deref()
+
+    pub fn get_url() -> String {
+        CONFIG.with(|cell| {
+            let config = cell.get().expect("UserConfig has not been initialized").borrow();
+            config.inner.url.clone()
+        })
     }
-    pub fn get_url(&self) -> &str {
-        self.config.url.as_ref()
+
+    pub fn get_default_org() -> Option<String> {
+        CONFIG.with(|cell| {
+            let config = cell.get().expect("UserConfig has not been initialized").borrow();
+            config.inner.default_org.clone()
+        })
     }
-    fn set_url(&mut self, url: String) {
-        self.config.url = url;
+
+    pub fn get_permissions() -> Vec<String> {
+        CONFIG.with(|cell| {
+            let config = cell.get().expect("UserConfig has not been initialized").borrow();
+            config.inner.permissions.clone()
+        })
+    }
+
+    pub fn set_token(token: Token) -> Result<(), Error> {
+        CONFIG.with(|cell| {
+            let mut config = cell.get().expect("UserConfig has not been initialized").borrow_mut();
+            config.disk_config.token = Some(token.clone());
+            config.inner.token = Some(token);
+            write_to_disk_json(&config.path, &config.disk_config)
+        })
+    }
+
+    pub fn set_default_org(org_name: String) -> Result<(), Error> {
+        CONFIG.with(|cell| {
+            let mut config = cell.get().expect("UserConfig has not been initialized").borrow_mut();
+            config.disk_config.default_org = Some(org_name.clone());
+            config.inner.default_org = Some(org_name);
+            write_to_disk_json(&config.path, &config.disk_config)
+        })
+    }
+
+    pub fn is_token_expired() -> bool {
+        CONFIG.with(|cell| {
+            let config = cell.get().expect("UserConfig has not been initialized").borrow();
+            config.inner.token
+              .as_ref()
+              .map(|u| u.expiry.is_some() && u.expiry.unwrap() < chrono::Utc::now())
+              .unwrap_or(false)
+        })
     }
 }
 
@@ -109,7 +146,7 @@ impl UserConfigLoader {
         let config = Config::builder().add_source(disk_config.clone()).build()?;
 
         Ok(UserConfig {
-            config: config.try_deserialize()?,
+            inner: config.try_deserialize()?,
             disk_config: disk_config.try_deserialize()?,
             path: path.clone(),
         })


### PR DESCRIPTION
This is still WIP, my idea was to hide commands from the help based on the user's permissions. The command can still be run even if the user doesn't have the permissions but then the API would reply with 403.
In order to update the permissions in the config, I plan to add a `auth refresh` command.