### PR TITLE
fix: remove short command for --container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "molnctl"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -520,7 +520,7 @@ fn get_image_tag(tag: &Option<String>) -> Result<String> {
 pub struct ImageName {
     #[arg(help = "The service name to update")]
     service: String,
-    #[arg(short, long, help = "Container name to update (within the service)")]
+    #[arg(long, help = "Container name to update (within the service)")]
     container: Option<String>,
     #[arg(short, long, help = "Image tag to use")]
     tag: Option<String>,


### PR DESCRIPTION
Cannot use the `svcs image-name` command currently as the short command for `container` conflicts with the global option `--config`. This removes the short command for `container` and fixes the issue.

The current error:
```
> molnctl svcs image-name molnettcom -q -u molnett.yaml

thread 'main' panicked at /home/mikn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.37/src/builder/debug_asserts.rs:112:17:
Command image-name: Short option names must be unique for each argument, but '-c' is in use by both 'container' and 'config'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```